### PR TITLE
Add email notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This project's goal is to enable teams to collect user feedback and organise wor
 It enables non github members to raise issues via a bot account, and github members to aggregates and track issues across different repositories.
 
 # Setup
+## Create Oauth applications in Azure and Github
+The app uses Azure Active Directory to authenticate users, and unlocks more functionalities for administators with a github account.
+To enable this, you need to create  OAuth applications on Azure and Github, and pass the relevant parameters to the app (see below).
+
+## Configure development environment
 to run this application, you need to provide secrets and constants as environment variables.
 
 An easy way to do this during development is to do it via an `.env` file.
@@ -11,25 +16,29 @@ An easy way to do this during development is to do it via an `.env` file.
 See below for an example `.env` file containing the definition for all the variables needed by both the front end and back end code:
 ```
 # Variables used by both back end and front end code
-REACT_APP_TENANT_ID=*some value*
-REACT_APP_CLIENT_ID=*some value*
-REACT_APP_GITHUB_CLIENT_ID=*some value*
+REACT_APP_TENANT_ID=*your azure tenant id*
+REACT_APP_CLIENT_ID=*the azure ad client id for your app*
+REACT_APP_GITHUB_CLIENT_ID=*github client id for your app*
 # Backend only
-GITHUB_CLIENT_SECRET=*some value*
+GITHUB_CLIENT_SECRET=*github client secret for your app*
 GITHUB_BOT_TOKEN=*bot account token with the 'repo' scope and allowed to access the configured repositories*
 IDENTITY_METADATA=https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
 GROUP_CONFIG_PATH='projects.json' *path to project configuration file. This should live in an folder ignored by git or out of the github repository used by azure deployments*
+SENDGRID_API_KEY=*your sendgrid api key*
+SENDGRID_EMAIL_SENDER='example@somedomain.com'
 # Front end only
-REACT_APP_ADMIN_GROUP_ID=*guid of Azure AD group containing admins*
+REACT_APP_ADMIN_GROUP_ID=*guid of Azure AD groups containing admins. use semicolon delimiter to list multiple groups*
 REACT_APP_GITHUB_BOT_LOGIN=*name of the bot account used to proxy requests*
 REACT_APP_DOMAIN_HINT= *your-domain.com - if known in advance, specifying this environment variable will ensure the Azure log in page automatically select the correct account if a user is logged in in multiple directories*
+# Optional, leave undefined to use the default stylesheets
+REACT_APP_BOOTSTRAP_CSS_PATH='../../app_data/bootstrap.css'
+REACT_APP_APPLICATION_STYLES_PATH='../../app_data/index.css'
 # Front end in development only
 HTTPS=true
 ```
-
-in production, you need to setup the environment variables before building and starting the application.
-
 For the time being, you will need to copy your .env file to `client/.env` manually before starting the development server, since the front end code expect to see its own .env file.
+
+in production, you will need to setup the environment variables before building and starting the application.
 
 # Install
 run `npm install` to install the required back end and front end dependencies.
@@ -44,4 +53,10 @@ Install node-foreman if needed (`npm i -g node-foreman`), then run `npm run debu
 To start the node server only, run `npm run debug-server` at the repo root.
 To start the front end dev-server only, run `cd client && npm start` at the repo root.
 
+# Deployment
+Define all the above variables as application settings on your azure web app. Then, you can deploy new versions of the app using azure's git deployment option for example. Azure will automatically install the relevant npm dependencies, build the front end code, and start the node server.
 
+**Note**: deployments are currently relatively slow, especially the first time since the `npm install` step needs to fetch all the packages. This is a known issue.
+
+If you want to enable email notifications, you will need to setup a web hook on github to send issue related events to the 
+`api/github-webhooks` endpoint, and a valid sendgrid api key.

--- a/api.js
+++ b/api.js
@@ -101,4 +101,10 @@ module.exports = function (app) {
     const r = request.post(proxyRequestOptions)
     req.pipe(r, genericErrorHandler).pipe(res);
   });
+
+  // handle github web hooks
+  app.post('/api/github-webhooks', passport.authenticate('oauth-bearer', { session: false }), function (req, res) {
+    console.log(`received web hook:\n${req.body}`);
+    res.json({ message: 'received web hook' });
+  });
 }

--- a/client/src/shared/requestUtils.js
+++ b/client/src/shared/requestUtils.js
@@ -1,8 +1,6 @@
-import _ from 'lodash';
-
 const qs = require('qs');
 
-export default function quoteRequestBody(body, userinfo) {
+const quoteRequestBody = function (body, userinfo) {
   if (!(userinfo.name && userinfo.id && (userinfo.email || userinfo.upn)))
     throw new Error(`User information must at least contain a name, an id, and either an email or upn property. The received value was ${JSON.stringify(userinfo)}`)
 
@@ -11,7 +9,7 @@ export default function quoteRequestBody(body, userinfo) {
 ${body}`
 }
 
-export function getCreator(issue) {
+const getCreator = function (issue) {
   if (issue.user.login === process.env.REACT_APP_GITHUB_BOT_LOGIN && issue.body.startsWith('> From')) {
     return parseUserInfoFromIssueBody(issue.body)
   } else {
@@ -19,7 +17,7 @@ export function getCreator(issue) {
   }
 }
 
-export function getContent(issue) {
+const getContent = function (issue) {
   if (issue.user.login === process.env.REACT_APP_GITHUB_BOT_LOGIN && issue.body.startsWith('> From')) {
     let lines = issue.body.split('\n')
     lines.splice(0, 2)
@@ -37,4 +35,10 @@ function parseUserInfoFromIssueBody(body) {
   encodedUserDetails = encodedUserDetails.split(')):')[0]
 
   return qs.parse(encodedUserDetails)
+}
+
+module.exports = {
+  getCreator,
+  getContent,
+  quoteRequestBody
 }

--- a/config.js
+++ b/config.js
@@ -7,7 +7,8 @@ const azure = {
 const github = {
   clientID: process.env.REACT_APP_GITHUB_CLIENT_ID,
   clientSecret: process.env.GITHUB_CLIENT_SECRET,
-  botToken: process.env.GITHUB_BOT_TOKEN
+  botToken: process.env.GITHUB_BOT_TOKEN,
+  botLogin: process.env.REACT_APP_GITHUB_BOT_LOGIN
 }
 
 const app = {

--- a/config.js
+++ b/config.js
@@ -11,7 +11,9 @@ const github = {
 }
 
 const app = {
-  groupConfigPath: process.env.GROUP_CONFIG_PATH
+  groupConfigPath: process.env.GROUP_CONFIG_PATH,
+  sendGridApiKey: process.env.SENDGRID_API_KEY,
+  emailSender: process.env.SENDGRID_EMAIL_SENDER
 }
 
 function validateConfig(configObject) {

--- a/notifications.js
+++ b/notifications.js
@@ -1,0 +1,93 @@
+var _ = require('lodash');
+
+const processIssues = (action, issue, projectName, requestLink) => {
+  switch (action) {
+    case 'opened':
+      return {
+        subject: `# Request Created # ${projectName} | ${issue.title}`,
+        content: `Thanks for submitting a <a href="${requestLink}">new request</a>. You will be notified when it is resolved.`
+      }
+      break;
+    case 'closed':
+      return {
+        subject: `# Request Closed # ${projectName} | ${issue.title}`,
+        content: `Your <a href="${requestLink}">request</a> has been closed, and the fix will be included in the next release.`
+      }
+      break;
+    case 'reopened':
+      return {
+        subject: `# Request Reopened # ${projectName} | ${issue.title}`,
+        content: `Your <a href="${requestLink}">request</a> has been reopened.`
+      }
+      break;
+    default:
+      throw new Error(`Invalid action: ${action}. Only "opened", "closed", "reopened" are currently supported.`)
+      break;
+  }
+}
+
+const processComment = (action, issue, comment, projectName, requestLink) => {
+  switch (action) {
+    case 'created':
+      return {
+        subject: `# Request Comment # ${projectName} | ${issue.title}`,
+        content: `A new comment has been posted on your <a href="${requestLink}">new request</a>.
+
+From <i>${comment.user.login}</i>:
+${comment.body}`
+      }
+      break;
+    case 'edited':
+      return {
+        subject: `# Request Comment # ${projectName} | ${issue.title}`,
+        content: `A comment has been edited on your <a href="${requestLink}">new request</a>.
+
+From <i>${comment.user.login}</i>:
+${comment.body}`
+      }
+      break;
+    case 'deleted':
+      return {
+        subject: `# Request Comment # ${projectName} | ${issue.title}`,
+        content: `A comment has been deleted on your <a href="${requestLink}">new request</a>.
+
+From <i>${comment.user.login}</i>:
+${comment.body}`
+      }
+      break;
+    default:
+      throw new Error(`Invalid action: ${action}. Only "added", "edited", "deleted" are supported.`)
+      break;
+  }
+}
+
+const getNotificationText = (eventType, payload, projectName, requestLink) => {
+  if (eventType === 'issues') {
+    return processIssues(payload.action, payload.issue, projectName, requestLink);
+  } else if (eventType === 'issue_comment') {
+    return processComment(payload.action, payload.issue, payload.comment, projectName, requestLink);
+  } else {
+    throw new Error(`invalid eventType:${eventType} only "issues" and "issue_comment" are currently supported.`)
+  }
+}
+
+const getRequestUrl = (issueNumber, project, appRootUrl) => {
+  return `${appRootUrl}/requests/${project.organisation}/${project.repository}/${encodeURIComponent(project.label)}/${issueNumber}`
+}
+
+const findProject = (payload, projects) => {
+  const organisation = payload.organization.login;
+  const repo = payload.repository.name;
+  const labels = payload.issue.labels.map(issue => issue.name);
+  const project = _.find(projects, p => p.organisation === organisation && p.repository === repo && labels.includes(p.label))
+  if (!project) {
+    throw new Error(`Unable to find a matching project for issue ${payload.issue.html_url}`)
+  }
+  return project;
+}
+
+module.exports = {
+  findProject,
+  getRequestUrl,
+  getNotificationText
+}

--- a/notifications.js
+++ b/notifications.js
@@ -4,20 +4,29 @@ const processIssues = (action, issue, projectName, requestLink) => {
   switch (action) {
     case 'opened':
       return {
-        subject: `# Request Created # ${projectName} | ${issue.title}`,
-        content: `Thanks for submitting a <a href="${requestLink}">new request</a>. You will be notified when it is resolved.`
+        subject: `[Request] [Created] [${projectName}] - ${issue.title}`,
+        content: `
+<p>Thanks for submitting a new request for <b>${projectName}</b>:</p>
+<p><a href="${requestLink}">${issue.title}</a></p>
+<p>You will be notified when it is resolved.</p>`
       }
       break;
     case 'closed':
       return {
-        subject: `# Request Closed # ${projectName} | ${issue.title}`,
-        content: `Your <a href="${requestLink}">request</a> has been closed, and the fix will be included in the next release.`
+        subject: `[Request] [Closed] [${projectName}] - ${issue.title}`,
+        content: `
+<p>Your request for <b>${projectName}</b>:</p>
+<p><a href="${requestLink}">${issue.title}</a></p>
+<p>has been closed. The fix will be included in the next release.</p>`
       }
       break;
     case 'reopened':
       return {
-        subject: `# Request Reopened # ${projectName} | ${issue.title}`,
-        content: `Your <a href="${requestLink}">request</a> has been reopened.`
+        subject: `[Request] [Reopened] [${projectName}] - ${issue.title}`,
+        content: `
+<p>Your request for <b>${projectName}</b>:</p>
+<p><a href="${requestLink}">${issue.title}</a></p>
+<p>has been reopened.<p>`
       }
       break;
     default:
@@ -30,29 +39,32 @@ const processComment = (action, issue, comment, projectName, requestLink) => {
   switch (action) {
     case 'created':
       return {
-        subject: `# Request Comment # ${projectName} | ${issue.title}`,
-        content: `A new comment has been posted on your <a href="${requestLink}">new request</a>.
-
-From <i>${comment.user.login}</i>:
-${comment.body}`
+        subject: `[Request] [New Comment] [${projectName}] - ${issue.title}`,
+        content: `
+<p>A new comment has been posted on your request for <b>${projectName}</b>:</p>
+<p><a href="${requestLink}">${issue.title}</a></p>
+<p>From <i>${comment.user.login}</i>:</p>
+<p>${comment.body}<p>`
       }
       break;
     case 'edited':
       return {
-        subject: `# Request Comment # ${projectName} | ${issue.title}`,
-        content: `A comment has been edited on your <a href="${requestLink}">new request</a>.
-
-From <i>${comment.user.login}</i>:
-${comment.body}`
+        subject: `[Request] [Edited Comment] [${projectName}] - ${issue.title}`,
+        content: `
+A comment has been edited on your request for <b>${projectName}</b>:</p>
+<p><a href="${requestLink}">${issue.title}</a></p>
+<p>From <i>${comment.user.login}</i>:</p>
+<p>${comment.body}<p>`
       }
       break;
     case 'deleted':
       return {
-        subject: `# Request Comment # ${projectName} | ${issue.title}`,
-        content: `A comment has been deleted on your <a href="${requestLink}">new request</a>.
-
-From <i>${comment.user.login}</i>:
-${comment.body}`
+        subject: `[Request] [Deleted Comment] [${projectName}] - ${issue.title}`,
+        content: `
+A comment has been deleted on your request for <b>${projectName}</b>:</p>
+<p><a href="${requestLink}">${issue.title}</a></p>
+<p>From <i>${comment.user.login}</i>:</p>
+<p>${comment.body}<p>`
       }
       break;
     default:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "author": "Clément Bouscasse",
   "dependencies": {
+    "body-parser": "^1.15.2",
     "cors": "^2.8.1",
     "dotenv": "^2.0.0",
     "express": "^4.14.0",
@@ -24,6 +25,7 @@
     "morgan": "^1.7.0",
     "passport": "^0.3.2",
     "passport-azure-ad": "^3.0.3",
-    "request": "^2.79.0"
+    "request": "^2.79.0",
+    "sendgrid": "^4.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^4.14.0",
     "file-stream-rotator": "0.0.7",
     "foreman": "^2.0.0",
+    "lodash": "^4.17.4",
     "morgan": "^1.7.0",
     "passport": "^0.3.2",
     "passport-azure-ad": "^3.0.3",

--- a/projects.json
+++ b/projects.json
@@ -13,9 +13,18 @@
     "projects": [
         {
             "name": "Test 1",
-            "label": "test 1",
+            "label": "test1",
             "groups": [
                 "group1"
+            ],
+            "organisation": "resgroup",
+            "repository": "test"
+        },
+        {
+            "name": "Test 1 with space in label",
+            "label": "test 1",
+            "groups": [
+                "group2"
             ],
             "organisation": "resgroup",
             "repository": "test"
@@ -40,9 +49,9 @@
         },
         {
             "name": "Test 3",
-            "label": "test_3",
+            "label": "test 3",
             "groups": [
-                "group2"
+                "group1"
             ],
             "organisation": "resgroup",
             "repository": "test"


### PR DESCRIPTION
This PR adds support for email notifications using [sendgrid](https://app.sendgrid.com/), since it is nicely integrated within azure.

To use this feature, a[ web hook](https://developer.github.com/webhooks/) need to be created on github, catching the `issues` and `issue_comment` events.

the hook should target `/api/github-webhook` at the deployed host.

It should be possible to set this up directly as long as the `/api/github-webhook` can be publicly accessed. If the whole app is guarded by azure 's "shell" authentication, a proxy step is required.
#21 will add the definition of an azure function that can be setup to that effect.
