### PR TITLE
Security Headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const app = require('./app');
+
+// remove the automatically added `X-Powered-By` header
+app.disable('x-powered-by');
+
 require('./api.js')(app);
 require('./static.js')(app);
 

--- a/server.js
+++ b/server.js
@@ -5,6 +5,18 @@ const app = require('./app');
 // remove the automatically added `X-Powered-By` header
 app.disable('x-powered-by');
 
+// this needs to be added first so that headers are added to all subsequent responses
+app.use(function (req, res, next) {
+
+  // security headers
+  // see https://www.owasp.org/index.php/OWASP_Secure_Headers_Project
+  res.header('X-XSS-Protection', '1; mode=block');
+  res.header('X-Frame-Options', 'deny');
+  res.header('X-Content-Type-Options', 'nosniff');
+
+  next();
+});
+
 require('./api.js')(app);
 require('./static.js')(app);
 

--- a/server.js
+++ b/server.js
@@ -8,6 +8,10 @@ app.disable('x-powered-by');
 // this needs to be added first so that headers are added to all subsequent responses
 app.use(function (req, res, next) {
 
+  // disable caching
+  res.header('Cache-Control', 'no-cache, must-revalidate, max-age=0');
+  res.header('Pragma', 'no-cache');
+
   // security headers
   // see https://www.owasp.org/index.php/OWASP_Secure_Headers_Project
   res.header('X-XSS-Protection', '1; mode=block');


### PR DESCRIPTION
### Add recommended security headers

The following headers are recommended by the [OWASP Secure Headers Project](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project) and are pretty straightforward to add:
 * `X-XSS-Protection`
 * `X-Frame-Options`
 * `X-Content-Type-Options`

OWASP lists some more headers, such as `Strict-Transport-Security` or `Content-Security-Policy`, but those really depend on how the app is deployed or require changes to the application's design.

### Disable caching by default

Adding the recommended `Cache-Control` header to all responses, as well as `Pragma` for legacy HTTP/1.0 clients.

### Remove the `X-Powered-By` header added by Express

The `X-Powered-By` header provides no real benefit and also leaks information about the design of the underlying system that may be useful to attackers.